### PR TITLE
Clean up option page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,20 +4,27 @@ import Underlying from './component/Trade/Underlying'
 
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
 import { Create } from './component/Create'
+import { Container, useTheme } from '@mui/material'
 
-export const App = () => (
-  <Router>
-    <Header />
-    <Switch>
-      <Route exact path="/">
-        <OptionsList />
-      </Route>
-      <Route path="/trade/:id">
-        <Underlying />
-      </Route>
-      <Route path="/create">
-        <Create />
-      </Route>
-    </Switch>
-  </Router>
-)
+export const App = () => {
+  const theme = useTheme()
+  return (
+    <Router>
+      <Header />
+
+      <Container sx={{ minHeight: '100vh', paddingTop: theme.spacing(4) }}>
+        <Switch>
+          <Route exact path="/">
+            <OptionsList />
+          </Route>
+          <Route path="/trade/:id">
+            <Underlying />
+          </Route>
+          <Route path="/create">
+            <Create />
+          </Route>
+        </Switch>
+      </Container>
+    </Router>
+  )
+}

--- a/src/component/Trade/CreateOrder.jsx
+++ b/src/component/Trade/CreateOrder.jsx
@@ -31,7 +31,6 @@ function a11yProps(index) {
 const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
   },
   tab: {
     width: 100,

--- a/src/component/Trade/OptionOrders.jsx
+++ b/src/component/Trade/OptionOrders.jsx
@@ -31,9 +31,7 @@ const TableHeader = styled.h4`
 `
 
 const TableHeadStyle = withStyles(() => ({
-  root: {
-    backgroundColor: 'rgb(134,217,192)',
-  },
+  root: {},
 }))(TableHead)
 
 const TableHeaderCell = withStyles(() => ({

--- a/src/component/Trade/OptionOrdersNew.jsx
+++ b/src/component/Trade/OptionOrdersNew.jsx
@@ -42,9 +42,7 @@ const TableHeader = styled.h4`
 `
 
 const TableHeadStyle = withStyles(() => ({
-  root: {
-    backgroundColor: 'rgb(134,217,192)',
-  },
+  root: {},
 }))(TableHead)
 
 const TableHeaderCell = withStyles(() => ({

--- a/src/component/Trade/OrderBook.jsx
+++ b/src/component/Trade/OrderBook.jsx
@@ -29,9 +29,7 @@ const TableHeader = styled.h4`
 `
 
 const TableHeadStyle = withStyles(() => ({
-  root: {
-    backgroundColor: 'rgb(134,217,192)',
-  },
+  root: {},
 }))(TableHead)
 
 const TableHeaderCell = withStyles(() => ({

--- a/src/component/Trade/OrderBookNew.jsx
+++ b/src/component/Trade/OrderBookNew.jsx
@@ -42,9 +42,7 @@ const NoOrderTextDiv = styled.div`
 `
 
 const TableHeadStyle = withStyles(() => ({
-  root: {
-    backgroundColor: 'rgb(134,217,192)',
-  },
+  root: {},
 }))(TableHead)
 
 const TableHeaderCell = withStyles(() => ({

--- a/src/component/Trade/Underlying.jsx
+++ b/src/component/Trade/Underlying.jsx
@@ -15,36 +15,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { setTradingOption } from '../../Redux/TradeOption'
 import { useHistory } from 'react-router-dom'
 import generatePayoffChartData from '../../Graphs/DataGenerator.js'
-import 'firebase/database'
-import 'firebase/firestore'
-
-const PageDiv = styled.div`
-  display: flex;
-  justify-content: space-around;
-  flex-basis: 80%;
-  margin-left: 10%;
-  margin-right: 10%;
-  padding: 10px;
-  margin-top: 2%;
-  border-radius: 1%;
-`
-
-const PageLeftDiv = styled.div`
-  flex: 90%;
-`
-
-const PageRightDiv = styled.div`
-  flex: 30%;
-  padding-left: 30px;
-`
-
-const LeftCompDiv = styled.div`
-  border: 1px solid rgba(224, 224, 224, 1);
-  margin: 25px;
-  padding: 1%;
-  border-radius: 15px;
-  background: white;
-`
+import { Paper, Stack } from '@mui/material'
 
 const LeftCompFlexContainer = styled.div`
   display: flex;
@@ -64,12 +35,6 @@ const LeftCompRightDiv = styled.div`
   align-items: stretch;
 `
 
-const RightCompDiv = styled.div`
-  border: 1px solid rgba(224, 224, 224, 1);
-  margin: 25px;
-  padding: 1%;
-  border-radius: 15px;
-`
 export default function Underlying() {
   const w = 380
   const h = 200
@@ -97,7 +62,7 @@ export default function Underlying() {
 
   const history = useHistory()
   if (Object.keys(selectedOption).length === 0) {
-    //Page refresh logic
+    // refresh logic
     const localOption = JSON.parse(window.localStorage.getItem('option'))
     setOption(localOption)
     dispatch(setTradingOption(localOption))
@@ -110,13 +75,14 @@ export default function Underlying() {
   })
 
   return (
-    <PageDiv>
-      <PageLeftDiv>
-        <LeftCompDiv>
+    <Stack direction="row" spacing={2}>
+      <Stack spacing={2}>
+        <Paper>
           <OptionHeader />
           <OptionDetails optionData={option} />
-        </LeftCompDiv>
-        <LeftCompDiv>
+        </Paper>
+
+        <Paper>
           <LeftCompFlexContainer>
             <LeftCompLeftDiv>
               <OrderBook />
@@ -125,13 +91,14 @@ export default function Underlying() {
               <OpenOrdersNew />
             </LeftCompRightDiv>
           </LeftCompFlexContainer>
-        </LeftCompDiv>
-      </PageLeftDiv>
-      <PageRightDiv>
-        <RightCompDiv>
+        </Paper>
+      </Stack>
+
+      <Stack spacing={2}>
+        <Paper>
           <CreateOrder />
-        </RightCompDiv>
-        <RightCompDiv>
+        </Paper>
+        <Paper>
           <TradeChart
             data={data}
             w={w}
@@ -139,8 +106,8 @@ export default function Underlying() {
             isLong={OptionParams.isLong}
             breakEven={breakEvenOptionPrice}
           />
-        </RightCompDiv>
-      </PageRightDiv>
-    </PageDiv>
+        </Paper>
+      </Stack>
+    </Stack>
   )
 }


### PR DESCRIPTION
I had already removed the white background colors so that this page works in dark mode too, but there seems to have been [a regression in this pr](https://github.com/divaprotocol/app/pull/48).

This pr fixes that and also cleans up the page a little and removes some custom css.

Before:
![image](https://user-images.githubusercontent.com/1188186/142374057-324da86b-067d-42b2-ba7d-ad95e4a1ce6b.png)

After:
![image](https://user-images.githubusercontent.com/1188186/142374125-9f41642f-366f-47bb-872c-a02e67c01cd4.png)

Also, just to prove that it works in light mode too:
![image](https://user-images.githubusercontent.com/1188186/142374183-4fad83a1-608c-4037-bca9-7b685a386f78.png)
