### PR TITLE
Fix: Variables on order page to match the graph

### DIFF
--- a/src/Graphs/DataGenerator.js
+++ b/src/Graphs/DataGenerator.js
@@ -36,9 +36,5 @@ export function generatePayoffChartData(data) {
     ]
   }
 
-  console.log({
-    data,
-    chartData,
-  })
   return chartData
 }

--- a/src/component/Trade/CreateOrder.jsx
+++ b/src/component/Trade/CreateOrder.jsx
@@ -126,25 +126,41 @@ export default function CreateOrder(props) {
     if (orderType === 0 && priceType === 0) {
       //Buy Market
       return (
-        <BuyMarket option={option} handleDisplayOrder={handleDisplayOrder} />
+        <BuyMarket
+          option={option}
+          handleDisplayOrder={handleDisplayOrder}
+          tokenAddress={props.tokenAddress}
+        />
       )
     }
     if (orderType === 0 && priceType === 1) {
       //Buy Limit
       return (
-        <BuyLimit option={option} handleDisplayOrder={handleDisplayOrder} />
+        <BuyLimit
+          handleDisplayOrder={handleDisplayOrder}
+          option={option}
+          tokenAddress={props.tokenAddress}
+        />
       )
     }
     if (orderType === 1 && priceType === 0) {
       //Sell Market
       return (
-        <SellMarket option={option} handleDisplayOrder={handleDisplayOrder} />
+        <SellMarket
+          option={option}
+          handleDisplayOrder={handleDisplayOrder}
+          tokenAddress={props.tokenAddress}
+        />
       )
     }
     if (orderType === 1 && priceType === 1) {
       //Sell Limit
       return (
-        <SellLimit option={option} handleDisplayOrder={handleDisplayOrder} />
+        <SellLimit
+          option={option}
+          handleDisplayOrder={handleDisplayOrder}
+          tokenAddress={props.tokenAddress}
+        />
       )
     }
   }

--- a/src/component/Trade/Orders/BuyLimit.tsx
+++ b/src/component/Trade/Orders/BuyLimit.tsx
@@ -18,6 +18,7 @@ import { CreateButtonWrapper } from './UiStyles'
 import { LimitOrderExpiryDiv } from './UiStyles'
 import { useStyles } from './UiStyles'
 import Web3 from 'web3'
+import { Pool } from '../../../lib/queries'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ERC20 = require('../abi/ERC20.json')
 const ERC20_ABI = ERC20.abi
@@ -25,8 +26,9 @@ const web3 = new Web3(Web3.givenProvider)
 let accounts
 
 export default function BuyLimit(props: {
-  option: any
+  option: Pool
   handleDisplayOrder: () => void
+  tokenAddress: string
 }) {
   const classes = useStyles()
   const option = props.option
@@ -34,7 +36,7 @@ export default function BuyLimit(props: {
   const [numberOfOptions, setNumberOfOptions] = React.useState(0.0)
   const [pricePerOption, setPricePerOption] = React.useState(0.0)
   const [collateralBalance, setCollateralBalance] = React.useState(0)
-  const takerToken = option.CollateralToken
+  const takerToken = option.collateralToken
   const takerTokenContract = new web3.eth.Contract(ERC20_ABI, takerToken)
 
   const handleNumberOfOptions = (value: string) => {
@@ -59,13 +61,13 @@ export default function BuyLimit(props: {
     accounts = await window.ethereum.enable()
     const orderData = {
       maker: accounts[0],
-      makerToken: option.CollateralToken,
-      takerToken: option.TokenAddress,
+      makerToken: option.collateralToken,
+      takerToken: props.tokenAddress,
       provider: web3,
       isBuy: true,
       nbrOptions: numberOfOptions,
       limitPrice: pricePerOption,
-      collateralDecimals: option.DecimalsCollateralToken,
+      collateralDecimals: option.collateralDecimals,
       orderExpiry: expiry,
     }
 
@@ -85,7 +87,7 @@ export default function BuyLimit(props: {
     let balance = await takerTokenContract.methods
       .balanceOf(takerAccount)
       .call()
-    balance = balance / 10 ** option.DecimalsCollateralToken
+    balance = balance / 10 ** option.collateralDecimals
     return balance
   }
 
@@ -126,7 +128,7 @@ export default function BuyLimit(props: {
             <LabelStyle>You Pay</LabelStyle>
           </LabelStyleDiv>
           <RightSideLabel>
-            {pricePerOption * numberOfOptions} {option.CollateralTokenName}
+            {pricePerOption * numberOfOptions} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>
@@ -135,7 +137,7 @@ export default function BuyLimit(props: {
           </LabelStyleDiv>
           <RightSideLabel>
             <LabelGrayStyle>
-              {collateralBalance} {option.CollateralTokenName}
+              {collateralBalance} {option.collateralTokenName}
             </LabelGrayStyle>
           </RightSideLabel>
         </FormDiv>

--- a/src/component/Trade/Orders/BuyMarket.tsx
+++ b/src/component/Trade/Orders/BuyMarket.tsx
@@ -24,6 +24,7 @@ import { Network } from '../../../Util/chainIdToName'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { BigNumber } from '@0x/utils'
 import Web3 from 'web3'
+import { Pool } from '../../../lib/queries'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ERC20 = require('../abi/ERC20.json')
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -33,7 +34,10 @@ const CHAIN_ID = Network.ROPSTEN
 const web3 = new Web3(Web3.givenProvider)
 let accounts: any[]
 
-export default function BuyMarket(props: { option: any }) {
+export default function BuyMarket(props: {
+  option: Pool
+  tokenAddress: string
+}) {
   const option = props.option
   const [value, setValue] = React.useState<string | number>(0)
   const [numberOfOptions, setNumberOfOptions] = React.useState(0.0)
@@ -43,11 +47,11 @@ export default function BuyMarket(props: { option: any }) {
 
   const address = contractAddress.getContractAddressesForChainOrThrow(CHAIN_ID)
   const exchangeProxyAddress = address.exchangeProxy
-  const makerToken = option.TokenAddress
+  const makerToken = props.tokenAddress
   const maxApproval = new BigNumber(2).pow(256).minus(1)
 
   const [collateralBalance, setCollateralBalance] = React.useState(0)
-  const takerToken = option.CollateralToken
+  const takerToken = option.collateralToken
   const takerTokenContract = new web3.eth.Contract(ERC20_ABI, takerToken)
 
   const handleNumberOfOptions = (value: string) => {
@@ -57,7 +61,7 @@ export default function BuyMarket(props: { option: any }) {
   const handleOrderSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     accounts = await window.ethereum.enable()
-    const takerTokenAddress = option.CollateralToken
+    const takerTokenAddress = option.collateralToken
     if (!isApproved) {
       //is ERC20_ABP correct? or should we use position token abi
       //ERC20_ABI enough to use approval
@@ -72,7 +76,7 @@ export default function BuyMarket(props: { option: any }) {
         .allowance(accounts[0], exchangeProxyAddress)
         .call()
       console.log('Approved by taker: ' + (await approvedByTaker.toString()))
-      alert(`Maker allowance for ${option.CollateralToken} successfully set`)
+      alert(`Maker allowance for ${option.collateralToken} successfully set`)
       setIsApproved(true)
     } else {
       const orderData = {
@@ -80,9 +84,9 @@ export default function BuyMarket(props: { option: any }) {
         provider: web3,
         isBuy: true,
         nbrOptions: numberOfOptions,
-        collateralDecimals: option.DecimalsCollateralToken,
+        collateralDecimals: option.collateralDecimals,
         makerToken: makerToken,
-        takerToken: option.CollateralToken,
+        takerToken: option.collateralToken,
         ERC20_ABI: ERC20_ABI,
       }
 
@@ -115,7 +119,7 @@ export default function BuyMarket(props: { option: any }) {
     let balance = await takerTokenContract.methods
       .balanceOf(takerAccount)
       .call()
-    balance = balance / 10 ** option.DecimalsCollateralToken
+    balance = balance / 10 ** option.collateralDecimals
     return balance
   }
 
@@ -152,7 +156,7 @@ export default function BuyMarket(props: { option: any }) {
             </LabelStyleDiv>
           </InfoTooltip>
           <RightSideLabel>
-            {pricePerOption} {option.CollateralTokenName}
+            {pricePerOption} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>
@@ -160,7 +164,7 @@ export default function BuyMarket(props: { option: any }) {
             <LabelStyle>You Pay</LabelStyle>
           </LabelStyleDiv>
           <RightSideLabel>
-            {pricePerOption} {option.CollateralTokenName}
+            {pricePerOption} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>
@@ -169,7 +173,7 @@ export default function BuyMarket(props: { option: any }) {
           </LabelStyleDiv>
           <RightSideLabel>
             <LabelGrayStyle>
-              {collateralBalance} {option.CollateralTokenName}
+              {collateralBalance} {option.collateralTokenName}
             </LabelGrayStyle>
           </RightSideLabel>
         </FormDiv>

--- a/src/component/Trade/Orders/SellLimit.tsx
+++ b/src/component/Trade/Orders/SellLimit.tsx
@@ -20,6 +20,7 @@ import { useStyles } from './UiStyles'
 import { Network } from '../../../Util/chainIdToName'
 import Web3 from 'web3'
 import { BigNumber } from '@0x/utils'
+import { Pool } from '../../../lib/queries'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ERC20 = require('../abi/ERC20.json')
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -33,8 +34,9 @@ const web3 = new Web3(Web3.givenProvider)
 let accounts: any[]
 
 export default function SellLimit(props: {
-  option: any
+  option: Pool
   handleDisplayOrder: () => void
+  tokenAddress: string
 }) {
   const classes = useStyles()
   const option = props.option
@@ -43,7 +45,7 @@ export default function SellLimit(props: {
   const [pricePerOption, setPricePerOption] = React.useState(0.0)
   const [isApproved, setIsApproved] = React.useState(false)
   const [walletBalance, setWalletBalance] = React.useState(0)
-  const makerToken = option.TokenAddress
+  const makerToken = props.tokenAddress
   const makerTokenContract = new web3.eth.Contract(ERC20_ABI, makerToken)
   const handleNumberOfOptions = (value: string) => {
     setNumberOfOptions(parseFloat(value))
@@ -59,7 +61,7 @@ export default function SellLimit(props: {
     let balance = await makerTokenContract.methods
       .balanceOf(makerAccount)
       .call()
-    balance = balance / 10 ** option.DecimalsCollateralToken
+    balance = balance / 10 ** option.collateralDecimals
     return balance
   }
 
@@ -80,13 +82,13 @@ export default function SellLimit(props: {
     } else {
       const orderData = {
         maker: makerAccount,
-        makerToken: option.TokenAddress,
-        takerToken: option.CollateralToken,
+        makerToken: props.tokenAddress,
+        takerToken: option.collateralToken,
         provider: web3,
         isBuy: false,
         nbrOptions: numberOfOptions,
         limitPrice: pricePerOption,
-        collateralDecimals: option.DecimalsCollateralToken,
+        collateralDecimals: option.collateralDecimals,
         orderExpiry: expiry,
       }
 
@@ -147,7 +149,7 @@ export default function SellLimit(props: {
             <LabelStyle>You Receive</LabelStyle>
           </LabelStyleDiv>
           <RightSideLabel>
-            {pricePerOption * numberOfOptions} {option.CollateralTokenName}
+            {pricePerOption * numberOfOptions} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>

--- a/src/component/Trade/Orders/SellMarket.tsx
+++ b/src/component/Trade/Orders/SellMarket.tsx
@@ -20,19 +20,23 @@ import { InfoTooltip } from './UiStyles'
 import { MaxSlippageText } from './UiStyles'
 import { ExpectedRateInfoText } from './UiStyles'
 import Web3 from 'web3'
+import { Pool } from '../../../lib/queries'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ERC20 = require('../abi/ERC20.json')
 const ERC20_ABI = ERC20.abi
 const web3 = new Web3(Web3.givenProvider)
 let accounts: any[]
 
-export default function SellMarket(props: { option: any }) {
+export default function SellMarket(props: {
+  option: Pool
+  tokenAddress: string
+}) {
   const option = props.option
   const [value, setValue] = React.useState<string | number>(0)
   const [numberOfOptions, setNumberOfOptions] = React.useState(5)
   const [pricePerOption, _setPricePerOption] = React.useState(0)
   const [walletBalance, setWalletBalance] = React.useState(0)
-  const makerToken = option.TokenAddress
+  const makerToken = props.tokenAddress
   const makerTokenContract = new web3.eth.Contract(ERC20_ABI, makerToken)
   const handleNumberOfOptions = (newValue: string) => {
     setNumberOfOptions(parseFloat(newValue))
@@ -68,7 +72,7 @@ export default function SellMarket(props: { option: any }) {
     let balance = await makerTokenContract.methods
       .balanceOf(makerAccount)
       .call()
-    balance = balance / 10 ** option.DecimalsCollateralToken
+    balance = balance / 10 ** option.collateralDecimals
     return balance
   }
 
@@ -105,7 +109,7 @@ export default function SellMarket(props: { option: any }) {
             </LabelStyleDiv>
           </InfoTooltip>
           <RightSideLabel>
-            {pricePerOption} {option.CollateralTokenName}
+            {pricePerOption} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>
@@ -113,7 +117,7 @@ export default function SellMarket(props: { option: any }) {
             <LabelStyle>You Receive</LabelStyle>
           </LabelStyleDiv>
           <RightSideLabel>
-            {pricePerOption} {option.CollateralTokenName}
+            {pricePerOption} {option.collateralTokenName}
           </RightSideLabel>
         </FormDiv>
         <FormDiv>

--- a/src/component/Trade/Underlying.tsx
+++ b/src/component/Trade/Underlying.tsx
@@ -93,7 +93,7 @@ export default function Underlying() {
 
       <Stack spacing={2}>
         <Paper>
-          <CreateOrder option={pool} />
+          <CreateOrder option={pool} tokenAddress={tokenAddress} />
         </Paper>
         <Paper>
           <TradeChart

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -80,9 +80,11 @@ export const queryPool = (poolId: number) => gql`
       supplyLong
       expiryDate
       collateralToken
+      collateralSymbol
       collateralBalanceShortInitial
       collateralBalanceLongInitial
       collateralBalanceShort
+      collateralDecimals
       collateralBalanceLong
       shortToken
       longToken


### PR DESCRIPTION
Technical Description:

This renames variables that needed to be renamed on the order page to match the api from thegraph. Should have been part of #79

fixes #84