### PR TITLE
Run tests on main and disable e2e tests for now

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Run eslint and typescript to check for errors
         run: yarn lint
 
-      - name: Run tests
-        run: yarn test:e2e
-        env: 
-          NETWORK_NAME: ropsten
-          SECRET_WORDS: ${{ secrets.TEST_WALLET_SECRET }}
+#      - name: Run tests
+#        run: yarn test:e2e
+#        env: 
+#          NETWORK_NAME: ropsten
+#          SECRET_WORDS: ${{ secrets.TEST_WALLET_SECRET }}


### PR DESCRIPTION
## Technical Description

This pr configures the github action workflow to also run for every commit on main as a way to ensure that tests don't fail on main. Previously the workflow only ran for pull requests

<!-- Description about changes in this pr. Must include explanation
of what this pr does and why it was proposed, please include relevant links
to issues and any information you think relevant -->

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
