### PR TITLE
reference asset and expiry time on same line

### DIFF
--- a/packages/app/src/component/CreatePool/DefinePoolAttributes.tsx
+++ b/packages/app/src/component/CreatePool/DefinePoolAttributes.tsx
@@ -210,7 +210,7 @@ export function DefinePoolAttributes({
           )}
         </FormControl>
       </Stack>
-      <Box>
+      <Box pb={4}>
         <h3>Collateral</h3>
 
         <Stack pb={3} spacing={2} direction="row">


### PR DESCRIPTION
## Technical Description

Expiry Date changed to Expiry Time and to save one line in Create tab  Expiry Time is moved next to Reference Asset.

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

![screenshot3](https://user-images.githubusercontent.com/47156004/155785368-2c23bcd4-f99d-45ef-9d09-9eac2b353049.png)
