### PR TITLE
Added Tooltip to collateral token on Trade page 

### DIFF
--- a/packages/diva-app/src/component/Trade/OptionDetails.tsx
+++ b/packages/diva-app/src/component/Trade/OptionDetails.tsx
@@ -165,13 +165,18 @@ export default function OptionDetails({
         </FlexBox>
         <FlexBox>
           <FlexBoxHeader>Collateral</FlexBoxHeader>
-          <FlexBoxData>
-            {Number(
-              formatUnits(pool.collateralBalance, pool.collateralToken.decimals)
-            ).toFixed(2) +
-              ' ' +
-              pool.collateralToken.symbol}
-          </FlexBoxData>
+          <Tooltip title={pool.collateralToken.id} arrow>
+            <FlexBoxData>
+              {Number(
+                formatUnits(
+                  pool.collateralBalance,
+                  pool.collateralToken.decimals
+                )
+              ).toFixed(2) +
+                ' ' +
+                pool.collateralToken.symbol}
+            </FlexBoxData>
+          </Tooltip>
         </FlexBox>
       </FlexDiv>
       <FlexSecondLineDiv>


### PR DESCRIPTION

## Technical Description

<!--User can now see and copy the collateral token address on the Trade page -->

### PR Checklist

- [x] Has the pr been tested manually by at least 1 reviewer?
- [x] Has all feedback been addressed?
- [x] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
![Screenshot 2022-05-17 173920](https://user-images.githubusercontent.com/47156004/168854718-f90c6a8a-c847-484d-80b4-a42e9975612d.png)

