### PR TITLE
fix: my position is not loading when switch the network

### DIFF
--- a/packages/diva-app/src/component/Dashboard/MyPositions.tsx
+++ b/packages/diva-app/src/component/Dashboard/MyPositions.tsx
@@ -23,7 +23,7 @@ import { useQuery } from 'react-query'
 import ERC20 from '@diva/contracts/abis/erc20.json'
 import styled from 'styled-components'
 import { GrayText } from '../Trade/Orders/UiStyles'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { CoinIconPair } from '../CoinIcon'
 import { useAppSelector } from '../../Redux/hooks'
 import {
@@ -434,6 +434,7 @@ const columns: GridColDef[] = [
 export function MyPositions() {
   const { provider, address: userAddress } = useConnectionContext()
   const [page, setPage] = useState(0)
+  const [filterPosition, setFilterPosition] = useState([])
   const pools = useAppSelector((state) => selectPools(state))
   const poolsRequestStatus = useAppSelector(selectRequestStatus('app/pools'))
 
@@ -578,26 +579,30 @@ export function MyPositions() {
     return response
   })
 
-  const tokenBalances = balances.data
+  useEffect(() => {
+    const tokenBalances = balances.data
 
-  const filteredRows =
-    tokenBalances != null
-      ? rows
-          .filter(
-            (v) =>
-              tokenBalances[v.address.id] != null &&
-              tokenBalances[v.address.id].gt(0)
-          )
-          .map((v) => ({
-            ...v,
-            Balance:
-              parseInt(formatUnits(tokenBalances[v.address.id])) < 0.01
-                ? '<0.01'
-                : parseFloat(formatUnits(tokenBalances[v.address.id])).toFixed(
-                    4
-                  ),
-          }))
-      : []
+    const filteredRows =
+      tokenBalances != null
+        ? rows
+            .filter(
+              (v) =>
+                tokenBalances[v.address.id] != null &&
+                tokenBalances[v.address.id].gt(0)
+            )
+            .map((v) => ({
+              ...v,
+              Balance:
+                parseInt(formatUnits(tokenBalances[v.address.id])) < 0.01
+                  ? '<0.01'
+                  : parseFloat(
+                      formatUnits(tokenBalances[v.address.id])
+                    ).toFixed(4),
+            }))
+        : []
+
+    setFilterPosition(filteredRows)
+  }, [balances])
 
   return (
     <Stack
@@ -627,7 +632,7 @@ export function MyPositions() {
           <SideMenu />
           <PoolsTable
             page={page}
-            rows={filteredRows}
+            rows={filterPosition}
             loading={balances.isLoading || poolsRequestStatus === 'pending'}
             columns={columns}
             onPageChange={(page) => setPage(page)}


### PR DESCRIPTION
## Technical Description

- Fix my positions are not loading when switching the network.

#### Note
- My position is now loading properly while switching the network. One issue remaining here is that the `useEffect` is rendering multiple times. This should not happen, the cause of the issue I think is `useQuery` hooks that fetch the balances. @juliankrispel is there something we can do to conditionally render `useQuery` hooks. 


### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

