### PR TITLE
Fixed payoff charts in Markets, My Position and My Data Feeds

### DIFF
--- a/packages/diva-app/src/component/Dashboard/MyDataFeeds.tsx
+++ b/packages/diva-app/src/component/Dashboard/MyDataFeeds.tsx
@@ -310,9 +310,22 @@ export function MyDataFeeds() {
       }
 
       const payOff = {
-        Floor: parseInt(val.floor) / 1e18,
-        Inflection: parseInt(val.inflection) / 1e18,
-        Cap: parseInt(val.cap) / 1e18,
+        CollateralBalanceLong: Number(
+          formatUnits(
+            val.collateralBalanceLongInitial,
+            val.collateralToken.decimals
+          )
+        ),
+        CollateralBalanceShort: Number(
+          formatUnits(
+            val.collateralBalanceShortInitial,
+            val.collateralToken.decimals
+          )
+        ),
+        Floor: Number(formatEther(val.floor)),
+        Inflection: Number(formatEther(val.inflection)),
+        Cap: Number(formatEther(val.cap)),
+        TokenSupply: Number(formatEther(val.supplyInitial)), // Needs adjustment to formatUnits() when switching to the DIVA Protocol 1.0.0 version
       }
 
       const Status = val.statusFinalReferenceValue

--- a/packages/diva-app/src/component/Dashboard/MyPositions.tsx
+++ b/packages/diva-app/src/component/Dashboard/MyPositions.tsx
@@ -521,9 +521,22 @@ export function MyPositions() {
     }
 
     const payOff = {
-      Floor: parseInt(val.floor) / 1e18,
-      Inflection: parseInt(val.inflection) / 1e18,
-      Cap: parseInt(val.cap) / 1e18,
+      CollateralBalanceLong: Number(
+        formatUnits(
+          val.collateralBalanceLongInitial,
+          val.collateralToken.decimals
+        )
+      ),
+      CollateralBalanceShort: Number(
+        formatUnits(
+          val.collateralBalanceShortInitial,
+          val.collateralToken.decimals
+        )
+      ),
+      Floor: Number(formatEther(val.floor)),
+      Inflection: Number(formatEther(val.inflection)),
+      Cap: Number(formatEther(val.cap)),
+      TokenSupply: Number(formatEther(val.supplyInitial)), // Needs adjustment to formatUnits() when switching to the DIVA Protocol 1.0.0 version
     }
 
     const Status =

--- a/packages/diva-app/src/component/Markets/Markets.tsx
+++ b/packages/diva-app/src/component/Markets/Markets.tsx
@@ -1,6 +1,6 @@
 import { GridColDef, GridRowModel } from '@mui/x-data-grid'
 import PoolsTable, { PayoffCell } from '../PoolsTable'
-import { formatUnits } from 'ethers/lib/utils'
+import { formatUnits, formatEther } from 'ethers/lib/utils'
 import { getDateTime } from '../../Util/Dates'
 import { generatePayoffChartData } from '../../Graphs/DataGenerator'
 import { BigNumber } from 'ethers'
@@ -120,9 +120,22 @@ export default function Markets() {
     }
 
     const payOff = {
-      Floor: parseInt(val.floor) / 1e18,
-      Inflection: parseInt(val.inflection) / 1e18,
-      Cap: parseInt(val.cap) / 1e18,
+      CollateralBalanceLong: Number(
+        formatUnits(
+          val.collateralBalanceLongInitial,
+          val.collateralToken.decimals
+        )
+      ),
+      CollateralBalanceShort: Number(
+        formatUnits(
+          val.collateralBalanceShortInitial,
+          val.collateralToken.decimals
+        )
+      ),
+      Floor: Number(formatEther(val.floor)),
+      Inflection: Number(formatEther(val.inflection)),
+      Cap: Number(formatEther(val.cap)),
+      TokenSupply: Number(formatEther(val.supplyInitial)), // Needs adjustment to formatUnits() when switching to the DIVA Protocol 1.0.0 version
     }
 
     return [


### PR DESCRIPTION
## Technical Description

The changes introduced in PR #350 were not implemented for all pages where payoff charts are used (Markets, My Positions, and My Data Feeds). This PR fixes this.

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?