### PR TITLE
fixed 383-fill order page reloaded issue

### DIFF
--- a/packages/diva-app/src/component/Trade/CreateOrder.tsx
+++ b/packages/diva-app/src/component/Trade/CreateOrder.tsx
@@ -19,6 +19,7 @@ import { fetchOrders, setIsBuy } from '../../Redux/appSlice'
 import { useDispatch } from 'react-redux'
 import { getUnderlyingPrice } from '../../lib/getUnderlyingPrice'
 import { setBreakEven } from '../../Redux/Stats'
+import { useAppSelector } from '../../Redux/hooks'
 const PageDiv = styled.div`
   justify-content: center
   height: 500px;
@@ -83,9 +84,11 @@ export default function CreateOrder(props: {
   const [orderType, setOrderTypeValue] = React.useState(0)
   const [priceType, setPriceTypeValue] = React.useState(0)
   const [usdPrice, setUsdPrice] = React.useState('')
+  let responseBuy = useAppSelector((state) => state.tradeOption.responseBuy)
+  let responseSell = useAppSelector((state) => state.tradeOption.responseSell)
   useEffect(() => {
     getExistingOrders()
-  }, [])
+  }, [orderType, priceType])
 
   const handleOrderTypeChange = (event: any, newValue: number) => {
     dispatch(setIsBuy(newValue === 0))
@@ -97,12 +100,13 @@ export default function CreateOrder(props: {
   }
 
   const getExistingOrders = async () => {
-    const responseSell: any = await get0xOpenOrders(
+    //updates orders components
+    responseSell = await get0xOpenOrders(
       props.tokenAddress,
       option.collateralToken.id,
       props.chainId
     )
-    const responseBuy: any = await get0xOpenOrders(
+    responseBuy = await get0xOpenOrders(
       option.collateralToken.id,
       props.tokenAddress,
       props.chainId


### PR DESCRIPTION
## Technical Description

<!-- Description about changes in this pr. Must include explanation
of what this pr does and why it was proposed, please include relevant links
to issues and any information you think relevant -->

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->

Fixed issue following is video recording.
https://www.loom.com/share/39866fb833314388b4921e244578bf38

along with reported issue fixed some outstanding issues
Buy & Sell market expected rate 're not updating without page refresh once the limit orders 're created.