### PR TITLE
Color update on orderbook

### DIFF
--- a/packages/diva-app/src/component/Trade/OrderBook.tsx
+++ b/packages/diva-app/src/component/Trade/OrderBook.tsx
@@ -301,7 +301,7 @@ export default function OrderBook(props: {
                     <TableCell align="center">
                       <Box>
                         <Typography variant="subtitle1" color="#ff5c8d">
-                          {row.ask != '' ? row.ask?.toString(4) : '-'}
+                          {row.ask != '' ? row.ask?.toFixed(4) : '-'}
                         </Typography>
                         <Typography variant="caption" color="#8e8e8e" noWrap>
                           {row.sellExpiry}


### PR DESCRIPTION
## Technical Description

- Grey font color for remaining time
- Greenish for BID prices
- Pinkish/reddish for ASK prices

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

![Screenshot 2022-06-03 204910](https://user-images.githubusercontent.com/47156004/171886382-06c04d0c-d646-4b8d-8209-e5aaae940baa.png)

