### PR TITLE
Fix expires in field

### DIFF
--- a/packages/diva-app/src/component/Markets/Markets.tsx
+++ b/packages/diva-app/src/component/Markets/Markets.tsx
@@ -19,11 +19,12 @@ import { useAppSelector } from '../../Redux/hooks'
 import { Box, Tooltip } from '@mui/material'
 import { ShowChartOutlined } from '@mui/icons-material'
 import { getAppStatus } from '../../Util/getAppStatus'
+import { isObject } from 'util'
 
 export const ExpiresInCell = (props: any) => {
   const expTimestamp = new Date(props.row.Expiry).getTime()
   const minUntilExp = getExpiryMinutesFromNow(expTimestamp / 1000)
-  if (minUntilExp >= 0) {
+  if (minUntilExp > 0) {
     if ((minUntilExp - (minUntilExp % (60 * 24))) / (60 * 24) > 0) {
       // More than a day
       return (
@@ -61,14 +62,7 @@ export const ExpiresInCell = (props: any) => {
       )
     } else if ((minUntilExp - (minUntilExp % 60)) / 60 === 0) {
       // Less than an hour
-      return minUntilExp === 0 ? (
-        <Tooltip
-          placement="top-end"
-          title={props.row.Expiry + ', ' + userTimeZone()}
-        >
-          <span className="table-cell-trucate">{'<1m'}</span>
-        </Tooltip>
-      ) : (
+      return (
         <Tooltip
           placement="top-end"
           title={props.row.Expiry + ', ' + userTimeZone()}
@@ -79,6 +73,16 @@ export const ExpiresInCell = (props: any) => {
         </Tooltip>
       )
     }
+  } else if (Object.is(0, minUntilExp)) {
+    // Using Object.is() to differentiate between +0 and -0
+    return (
+      <Tooltip
+        placement="top-end"
+        title={props.row.Expiry + ', ' + userTimeZone()}
+      >
+        <span className="table-cell-trucate">{'<1m'}</span>
+      </Tooltip>
+    )
   } else {
     return (
       <Tooltip


### PR DESCRIPTION
## Technical Description

'Expires in' field in Markets, My Positions and My Data Feeds tables was not displaying '<1m'. Now it does.

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?