### PR TITLE
Disallow letter inputs in all number fields

### DIFF
--- a/packages/diva-app/src/component/Trade/Orders/BuyLimit.tsx
+++ b/packages/diva-app/src/component/Trade/Orders/BuyLimit.tsx
@@ -90,7 +90,7 @@ export default function BuyLimit(props: {
     const nbrOptions = parseFloat(value)
     if (!isNaN(nbrOptions)) {
       setNumberOfOptions(nbrOptions)
-      if (pricePerOption > 0 && nbrOptions > 0) {
+      if (pricePerOption > 0 && nbrOptions > 0.0) {
         const youPay = pricePerOption * nbrOptions
         setYouPay(youPay)
         setOrderBtnDisabled(false)
@@ -504,6 +504,8 @@ export default function BuyLimit(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.01"
+            min="0"
             onChange={(event) => handleNumberOfOptions(event.target.value)}
           />
         </FormDiv>
@@ -523,6 +525,8 @@ export default function BuyLimit(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.01"
+            min="0"
             onChange={(event) => handlePricePerOptions(event.target.value)}
           />
         </FormDiv>

--- a/packages/diva-app/src/component/Trade/Orders/BuyMarket.tsx
+++ b/packages/diva-app/src/component/Trade/Orders/BuyMarket.tsx
@@ -559,6 +559,8 @@ export default function BuyMarket(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.01"
+            min="0"
             onChange={(event) => handleNumberOfOptions(event.target.value)}
           />
         </FormDiv>

--- a/packages/diva-app/src/component/Trade/Orders/SellLimit.tsx
+++ b/packages/diva-app/src/component/Trade/Orders/SellLimit.tsx
@@ -511,6 +511,8 @@ export default function SellLimit(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.1"
+            min="0"
             onChange={(event) => handleNumberOfOptions(event.target.value)}
           />
         </FormDiv>
@@ -530,6 +532,8 @@ export default function SellLimit(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.1"
+            min="0"
             onChange={(event) => handlePricePerOptions(event.target.value)}
           />
         </FormDiv>

--- a/packages/diva-app/src/component/Trade/Orders/SellMarket.tsx
+++ b/packages/diva-app/src/component/Trade/Orders/SellMarket.tsx
@@ -538,6 +538,8 @@ export default function SellMarket(props: {
           </FormLabel>
           <FormInput
             type="number"
+            step="0.01"
+            min="0"
             onChange={(event) => handleNumberOfOptions(event.target.value)}
           />
         </FormDiv>


### PR DESCRIPTION
Currently, all the number fields on the trade page accept the characters. This PR covered disallowing all the character inputs in all the number fields.

## Technical Description

<!-- Description about changes in this pr. Must include explanation
of what this pr does and why it was proposed, please include relevant links
to issues and any information you think relevant -->

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [x] Has all feedback been addressed?
- [x] Are all tests and linters running without error?
- [x] Users cannot enter characters in number fields

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
