### PR TITLE
Cloudfront invalidation had wrong path

### DIFF
--- a/.github/workflows/deploy-infrastructure-and-website.yml
+++ b/.github/workflows/deploy-infrastructure-and-website.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'packages/diva-app/**'
       - 'packages/diva-infrastructure/**'
-      - '.github/workflows/deploy-infrastructure.yml'
+      - '.github/workflows/deploy-infrastructure-and-website.yml'
 
 name: Deploy Infrastructure
 jobs:


### PR DESCRIPTION
## Technical Description

The cloudfront cache was not getting invalidated correctly so users saw the previously cached version.

Cloudfront invalidation was using the wrong path glob - we were using `/*/*` when we should have been using `/*` - here are related docs for further reading https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html
