### PR TITLE
Empty pools array when pools query is loading

### DIFF
--- a/packages/diva-app/src/Redux/appSlice.ts
+++ b/packages/diva-app/src/Redux/appSlice.ts
@@ -264,6 +264,7 @@ export const appSlice = createSlice({
 
     builder.addCase(fetchPools.pending, (state, action) => {
       const poolState = state[state.chainId]
+      poolState.pools = []
       poolState.statusByName[
         action.type.substring(0, action.type.length - ('pending'.length + 1))
       ] = 'pending'


### PR DESCRIPTION
## Technical Description

Empties pool array as soon as we load a new set of pools

### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
