### PR TITLE
Updated layout for the data shown in the chart in the mobile view and trade page

### DIFF
--- a/packages/diva-app/src/component/Graphs/TradeChart.jsx
+++ b/packages/diva-app/src/component/Graphs/TradeChart.jsx
@@ -304,11 +304,11 @@ export default function DIVATradeChart(props) {
       .append('circle')
       .attr(
         'cx',
-        isLegendResponsive
+        isLegendResponsive && currentPrice
           ? legendXPos.breakEvenCircle
           : newlegendXPos.breakEvenCircle
       )
-      .attr('cy', newLegendHeight)
+      .attr('cy', currentPrice ? newLegendHeight : legendHeight)
       .attr('r', showBreakEven && breakEven != 'n/a' ? 6 : 0)
       .style('fill', '#9747FF')
 
@@ -370,11 +370,11 @@ export default function DIVATradeChart(props) {
       .append('text')
       .attr(
         'x',
-        isLegendResponsive
+        isLegendResponsive && currentPrice
           ? legendXPos.breakEvenText
           : newlegendXPos.breakEvenText
       )
-      .attr('y', newLegendHeight)
+      .attr('y', currentPrice ? newLegendHeight : legendHeight)
       .attr('opacity', showBreakEven && breakEven != 'n/a' ? 1 : 0)
       .text('Break Even' + ' ' + '(' + parseFloat(breakEven).toFixed(2) + ')')
       .style('font-size', '12px')


### PR DESCRIPTION
## Technical Description

Now the data shown under the chart on the trade page and on the market page mobile view is responsive.  
https://www.figma.com/proto/mcyci32XlFZJ8K1JZa25Ts/Diva-App?node-id=5864%3A37785&scaling=scale-down&page-id=5864%3A37783&starting-point-node-id=5864%3A37785

![Screenshot 2022-10-10 185422](https://user-images.githubusercontent.com/47156004/194876956-7eb0887a-6c3c-4822-8a7e-21dc3da73f9a.png)
![Screenshot 2022-10-10 185533](https://user-images.githubusercontent.com/47156004/194876966-b407ca4a-2f3f-4c9b-b4e8-d547694a0507.png)


### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
