### PR TITLE
fix timestamp

### DIFF
--- a/packages/diva-oracle/lib/Prices.py
+++ b/packages/diva-oracle/lib/Prices.py
@@ -1,51 +1,54 @@
-from datetime import datetime
-import string
+import datetime
 import requests
 import pandas as pd
 import json
 from config.config import WHITELIST_TOKEN_POOLS
 from config.config import BLOCK_ON_WHITELIST
+from config.config import max_time_away
 
 
-def getKrakenPrice(pair, ts_date, ts_date_max_away):
-    url = 'https://api.kraken.com/0/public/Trades?pair={}'.format(
-        pair) + '&since={}'.format(ts_date_max_away)
-    resp = requests.get(url)
-    #print("LOG: ", resp)
-    data = json.loads(resp.content.decode('utf-8'))
-    keys = list(data)
-    if data[keys[0]] == []:
-        keys2 = list(data[keys[1]])
+def getKrakenPrice(pair, ts_date):
+    max_away = datetime.timedelta(minutes=max_time_away)
+    for t in range(1, int(max_away.seconds/60)):
+        url = 'https://api.kraken.com/0/public/Trades?pair={}'.format(
+        pair) + '&since={}'.format(ts_date-t*60)
+        resp = requests.get(url)
+        #print("LOG: ", resp)
+        data = json.loads(resp.content.decode('utf-8'))
+        keys = list(data)
 
-        df = pd.json_normalize(data, [keys[1], keys2[0]])
-        if df.empty:
-            print("no kraken data")
-            return -1, -1
-        df.columns = ['price', 'volume', 'time',
-                      'buy/sell', 'market/limit', 'misc']
-        df['datetime'] = df['time'].apply(lambda x: datetime.fromtimestamp(x))
+        if not data[keys[0]]:
+            keys2 = list(data[keys[1]])
 
-        df_reduced = df.loc[df['time'] <= ts_date-60]
-        if not df_reduced.empty:
-            price_kraken = float(df_reduced.iloc[-1, 0])
-            price_kraken_rounded = round(price_kraken, 2)
-            date_kraken = df_reduced.iloc[-1, -1]
-            return(price_kraken_rounded, date_kraken)
+            df = pd.json_normalize(data, [keys[1], keys2[0]])
+            if df.empty:
+                print("no kraken data")
+                return -1, -1
+            df.columns = ['price', 'volume', 'time',
+                          'buy/sell', 'market/limit', 'misc']
+            # df['datetime'] = df['time'].apply(lambda x: datetime.fromtimestamp(x))
+
+            df_reduced = df.loc[df['time'] <= ts_date]
+            if not df_reduced.empty:
+                price_kraken = float(df_reduced.iloc[-1, 0])
+                price_kraken_rounded = round(price_kraken, 2)
+                date_kraken = df_reduced.iloc[-1, 2]
+                return price_kraken_rounded, date_kraken
+
+            elif t == int(max_away.seconds/60):
+                print("No available price for pair ", pair, " in the specified time frame.")
+                return -1, -1
         else:
-            print("No available price for pair ", pair, " between ", datetime.fromtimestamp(
-                ts_date_max_away), " and ", datetime.fromtimestamp(ts_date))
+            print("Error: ", data[keys[0]][0], "for pair ", pair)
             return -1, -1
-    else:
-        print("Error: ", data[keys[0]][0], "for pair ", pair)
-        return -1, -1
 
 
-def getKrakenCollateralConversion(dfitem, dfcontract, ts_date, ts_date_max_away):
+def getKrakenCollateralConversion(dfitem, dfcontract, ts_date):
     pair = dfitem+"USD"
     white_list_status = check_whitelist_token(dfitem, dfcontract)
     if white_list_status == "NotWhiteListed" and BLOCK_ON_WHITELIST:
         return white_list_status
-    price = getKrakenPrice(pair, ts_date, ts_date_max_away)
+    price = getKrakenPrice(pair, ts_date)
     # This is for auto price to one in testing of dUSD
     if price[0] == -1:
         return 1
@@ -56,7 +59,7 @@ def check_whitelist_token(dfitem, dfcontract):
         #print(dfitem)
         #print(WHITELIST_TOKEN_POOLS)
         if dfitem in WHITELIST_TOKEN_POOLS:
-            print("Valid whitelisted Token {}, {}".format(dfitem, dfcontract ))
+            print("Valid whitelisted Token {}, {}".format(dfitem, dfcontract))
             print(WHITELIST_TOKEN_POOLS.get(dfitem))
             return("whitelisted")
         else:

--- a/packages/diva-oracle/lib/QueryGraph.py
+++ b/packages/diva-oracle/lib/QueryGraph.py
@@ -1,7 +1,4 @@
 import requests
-import pandas as pd
-from datetime import datetime
-
 
 # function to use requests.post to make an API call to the subgraph url
 def run_graph_query(query, network):
@@ -18,8 +15,7 @@ def run_graph_query(query, network):
 
 def transform_expiryTimes(df):
     df['expiryTime'] = df['expiryTime'].apply(lambda x: float(x))
-    df['expiryTime_datetime'] = df['expiryTime'].apply(lambda x: datetime.fromtimestamp(x))
-    df['Passed Seconds After Expiry'] = df['expiryTime_datetime'].apply(lambda x: (datetime.now()-x).total_seconds())
+    # df['Passed Seconds After Expiry'] = df['expiryTime'].apply(lambda x: (datetime.now().timestamp()-x))
     return df
 
 

--- a/packages/diva-oracle/tellor_main.py
+++ b/packages/diva-oracle/tellor_main.py
@@ -1,26 +1,15 @@
-from web3 import Web3
 import tellor_settings.tellor_abi as tellor
-from tellor_settings.tellor_submission import submitTellorValue
-from tellor_settings.tellor_setFinalReferenceValue import setFinRefVal
 import tellor_settings.tellor_contracts as tellor_contracts
-import time
 import datetime as dt
-from lib.Prices import getKrakenPrice
 from lib.QueryGraph import *
-from lib.SendPrice import sendPrice
 import config.config as config
-import threading
 from web3 import Web3
 import time
-import config.diva as diva
-from lib.sendEmail import sendEmail
-from lib.recorder import *
-from lib.df_utils import extend_DataFrame
-from lib.query import tellor_query, query
-from lib.submitPool import submitPools, tellor_submit_pools
+from lib.query import tellor_query
+from lib.submitPool import  tellor_submit_pools
+import pandas as pd
 
 
-from colorama import init
 from termcolor import colored
 
 waiting_sec = 60
@@ -46,4 +35,3 @@ if __name__ == "__main__":
         print(colored("Waiting {} sec before next iteration...".format(waiting_sec), 'yellow'))
         # Wait before next iteration
         time.sleep(waiting_sec)
-        


### PR DESCRIPTION
fix timestamp
## Technical Description

Two things were fixed:
1) timestamps were converted to datetimes and then back to timestamps which resulted in wrong timestamps.
-> everything is now done with timestamp and we do not convert to datetime.

2) The Kraken API only returns the latest 1000 prices. This means if we fetch prices starting from the timestamp `max_time_away` it can be that the `expiryTime` is not in the data. Example: If there are prices every second and `max_time_away= 60 min` then we have 3600 prices between `max_time_away` and `expiryTime ` and only fetch the first 1000. 
-> We solve this by fetching all prices starting from `expiryTime - 1 min` . If this is empty we fetch prices starting from `expiryTime - 2 min`, and so on until `expiryTime - max_time_away`.


### PR Checklist

- [ ] Has the pr been tested manually by at least 1 reviewer?
- [ ] Has all feedback been addressed?
- [ ] Are all tests and linters running without error?

### Screenshots / Screen-recordings

<!-- Add any relevant screenshots or screen-recordings as supporting material. -->
