### PR TITLE
Fix/add remove liquidity

### DIFF
--- a/packages/diva-app/src/component/CreatePool/DefineOfferAtributes.tsx
+++ b/packages/diva-app/src/component/CreatePool/DefineOfferAtributes.tsx
@@ -612,7 +612,7 @@ export function DefineOfferAttributes({
                       {toExponentialOrNumber(
                         parseFloat(collateralWalletBalance)
                       )}{' '}
-                      {collateralToken?.symbol}{' '}
+                      {collateralToken?.symbol} {'('}
                       <MaxCollateral
                         role="button"
                         onClick={() => {
@@ -624,8 +624,9 @@ export function DefineOfferAttributes({
                           }
                         }}
                       >
-                        (Max)
+                        Max
                       </MaxCollateral>
+                      {')'}
                     </FormHelperText>
                   )}
                 </FormControl>

--- a/packages/diva-app/src/component/CreatePool/DefinePoolAttributes.tsx
+++ b/packages/diva-app/src/component/CreatePool/DefinePoolAttributes.tsx
@@ -558,7 +558,7 @@ export function DefinePoolAttributes({
                     <FormHelperText>
                       Your balance:{' '}
                       {toExponentialOrNumber(Number(collateralWalletBalance))}{' '}
-                      {collateralToken?.symbol}{' '}
+                      {collateralToken?.symbol} {'('}
                       <MaxCollateral
                         role="button"
                         onClick={() => {
@@ -570,8 +570,9 @@ export function DefinePoolAttributes({
                           }
                         }}
                       >
-                        (Max)
+                        Max
                       </MaxCollateral>
+                      {')'}
                     </FormHelperText>
                   )}
                 </FormControl>

--- a/packages/diva-app/src/component/CreatePool/FillOffer.tsx
+++ b/packages/diva-app/src/component/CreatePool/FillOffer.tsx
@@ -88,8 +88,7 @@ export function FillOffer({
       formik.setFieldValue('collateralToken.id', configJson.collateralToken)
       formik.setFieldValue(
         'capacity',
-        configJson.capacity ===
-          '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+        configJson.capacity === ethers.constants.MaxUint256.toString()
           ? 'Unlimited'
           : configJson.capacity
       )

--- a/packages/diva-app/src/component/CreatePool/Offer.tsx
+++ b/packages/diva-app/src/component/CreatePool/Offer.tsx
@@ -113,7 +113,7 @@ export function Offer() {
       formik.setFieldValue(
         'capacity',
         jsonResponse.data.data.capacity ===
-          '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+          ethers.constants.MaxUint256.toString()
           ? 'Unlimited'
           : jsonResponse.data.data.capacity
       )

--- a/packages/diva-app/src/component/Liquidity/RemoveLiquidity.tsx
+++ b/packages/diva-app/src/component/Liquidity/RemoveLiquidity.tsx
@@ -23,9 +23,12 @@ import ERC20 from '../../abi/ERC20ABI.json'
 import Button from '@mui/material/Button'
 import { config } from '../../constants'
 import DIVA_ABI from '../../abi/DIVAABI.json'
+import { toExponentialOrNumber } from '../../Util/utils'
 import { fetchPool } from '../../Redux/appSlice'
 import { useDispatch } from 'react-redux'
+import { selectUserAddress } from '../../Redux/appSlice'
 import { useConnectionContext } from '../../hooks/useConnectionContext'
+import { useAppSelector } from '../../Redux/hooks'
 import LightbulbIcon from '@mui/icons-material/Lightbulb'
 
 const MaxCollateral = styled.u`
@@ -54,9 +57,12 @@ export const RemoveLiquidity = ({ pool }: Props) => {
   const [maxCollateral, setMaxCollateral] = React.useState<any>(0)
   const [balanceUpdated, setBalanceUpdated] = React.useState(true)
   const { provider } = useConnectionContext()
+  const account = useAppSelector(selectUserAddress)
   const chainId = provider?.network?.chainId
   const dispatch = useDispatch()
   const theme = useTheme()
+
+  // TODO Move this part into the useEffect hook so that it updates the user balance on account switch
   const tokenBalanceLong = useErcBalance(
     pool ? pool!.longToken.id : undefined,
     balanceUpdated
@@ -145,7 +151,14 @@ export const RemoveLiquidity = ({ pool }: Props) => {
     } else {
       setOpenAlert(false)
     }
-  }, [tokenBalanceLong, tokenBalanceShort, textFieldValue, chainId, pool])
+  }, [
+    tokenBalanceLong,
+    tokenBalanceShort,
+    textFieldValue,
+    chainId,
+    pool,
+    account,
+  ])
 
   async function removeLiquidityTrade() {
     try {


### PR DESCRIPTION
## Technical Description

fixing add and remove liquidity parts.

TODO:
* [ ] Token balances do not refresh on account switch in both add and remove liquidity
* [x] `AddLiquidity.tsx`, line 323: Cannot use `toExponentialOrNumber(remainingAllowance)` becaue `remainingAllowance` seems to be undefined
* [x] "Currently utilized in %" does not refresh after adding liquidity (only relevant for pools with limited capacity; check pool 62 for instance)
* [x] Add collateral token symbol on the right in input field for both Add and Remove liquidity