### PR TITLE
split governance address

### DIFF
--- a/packages/diva-app/src/App.tsx
+++ b/packages/diva-app/src/App.tsx
@@ -10,7 +10,7 @@ import Markets from './component/Markets/Markets'
 import { useAppSelector } from './Redux/hooks'
 import { LoadingBox } from './component/LoadingBox'
 
-import { config, DIVA_GOVERNANCE_ADDRESS } from './constants'
+import { config, DEFAULT_MARKETS_CREATED_BY } from './constants'
 import { WrongChain } from './component/Wallet/WrongChain'
 import Dashboard from './component/Dashboard/Dashboard'
 import { Offer } from './component/CreatePool/Offer'
@@ -46,7 +46,7 @@ export const App = () => {
             <CreatePool />
           </Route>
           <Route path="/">
-            <Redirect from="/" to={`/markets/${DIVA_GOVERNANCE_ADDRESS}`} />
+            <Redirect from="/" to={`/markets/${DEFAULT_MARKETS_CREATED_BY}`} />
           </Route>
         </Switch>
       ) : (

--- a/packages/diva-app/src/DataService/OpenOrders.ts
+++ b/packages/diva-app/src/DataService/OpenOrders.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import {
   config,
   NULL_ADDRESS,
-  DIVA_GOVERNANCE_ADDRESS,
+  TRADING_FEE_RECIPIENT,
   TRADING_FEE,
 } from '../constants'
 import { BigNumber, ethers } from 'ethers'

--- a/packages/diva-app/src/Orders/BuyLimit.js
+++ b/packages/diva-app/src/Orders/BuyLimit.js
@@ -1,7 +1,7 @@
 import { parseUnits, splitSignature } from 'ethers/lib/utils'
 import { NULL_ADDRESS } from './Config'
 import { config } from '../constants'
-import { DIVA_GOVERNANCE_ADDRESS, TRADING_FEE } from '../constants'
+import { TRADING_FEE_RECIPIENT, TRADING_FEE } from '../constants'
 import { getFutureExpiryInSeconds } from '../Util/utils'
 import { zeroXTypes, zeroXDomain } from '../lib/zeroX'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -38,7 +38,7 @@ export const buylimitOrder = async (orderData) => {
     takerAmount: nbrOptionsToBuy.toString(),
     maker: orderData.maker,
     sender: NULL_ADDRESS,
-    feeRecipient: DIVA_GOVERNANCE_ADDRESS,
+    feeRecipient: TRADING_FEE_RECIPIENT,
     takerTokenFeeAmount: positionTokenFeeAmount.toString(),
     expiry: getFutureExpiryInSeconds(orderData.orderExpiry),
     salt: Date.now().toString(),

--- a/packages/diva-app/src/Orders/SellLimit.js
+++ b/packages/diva-app/src/Orders/SellLimit.js
@@ -2,7 +2,7 @@ import { parseUnits, splitSignature } from 'ethers/lib/utils'
 import { NULL_ADDRESS } from './Config'
 import { utils } from './Config'
 import { config } from '../constants'
-import { DIVA_GOVERNANCE_ADDRESS, TRADING_FEE } from '../constants'
+import { TRADING_FEE_RECIPIENT, TRADING_FEE } from '../constants'
 import { getFutureExpiryInSeconds } from '../Util/utils'
 import { zeroXTypes, zeroXDomain } from '../lib/zeroX'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -40,7 +40,7 @@ export const sellLimitOrder = async (orderData) => {
     takerAmount: collateralTokenAmount.toString(),
     maker: orderData.maker,
     sender: NULL_ADDRESS,
-    feeRecipient: DIVA_GOVERNANCE_ADDRESS,
+    feeRecipient: TRADING_FEE_RECIPIENT,
     takerTokenFeeAmount: collateralTokenFeeAmount.toString(),
     expiry: getFutureExpiryInSeconds(orderData.orderExpiry),
     salt: Date.now().toString(),

--- a/packages/diva-app/src/Redux/appSlice.ts
+++ b/packages/diva-app/src/Redux/appSlice.ts
@@ -27,7 +27,8 @@ import {
 } from '../Models/orderbook'
 import {
   config,
-  DIVA_GOVERNANCE_ADDRESS,
+  DEFAULT_MARKETS_CREATED_BY,
+  TRADING_FEE_RECIPIENT,
   NULL_ADDRESS,
   DEFAULT_TAKER_TOKEN_FEE,
   DEFAULT_THRESHOLD,
@@ -234,7 +235,7 @@ export const fetchPools = createAsyncThunk(
     })
 
     const taker = NULL_ADDRESS
-    const feeRecipient = DIVA_GOVERNANCE_ADDRESS
+    const feeRecipient = TRADING_FEE_RECIPIENT
     const takerTokenFee = DEFAULT_TAKER_TOKEN_FEE
     const threshold = DEFAULT_THRESHOLD
     const count = 1
@@ -582,12 +583,12 @@ export const selectToken = (state: RootState, poolId: string) => {
 
 export const selectMainPools = (state: RootState) =>
   selectAppStateByChain(state).pools.filter(
-    (p) => p?.createdBy === DIVA_GOVERNANCE_ADDRESS.toLowerCase()
+    (p) => p?.createdBy === DEFAULT_MARKETS_CREATED_BY.toLowerCase()
   )
 
 export const selectOtherPools = (state: RootState) =>
   selectAppStateByChain(state).pools.filter(
-    (p) => p?.createdBy !== DIVA_GOVERNANCE_ADDRESS.toLowerCase()
+    (p) => p?.createdBy !== DEFAULT_MARKETS_CREATED_BY.toLowerCase()
   )
 
 export const selectChainId = (state: RootState) => state.appSlice.chainId

--- a/packages/diva-app/src/component/Markets/Markets.tsx
+++ b/packages/diva-app/src/component/Markets/Markets.tsx
@@ -19,7 +19,7 @@ import { ShowChartOutlined } from '@mui/icons-material'
 import { useHistory, useParams } from 'react-router-dom'
 import FilterListIcon from '@mui/icons-material/FilterList'
 
-import { DIVA_GOVERNANCE_ADDRESS } from '../../constants'
+import { DEFAULT_MARKETS_CREATED_BY } from '../../constants'
 import PoolsTable, { PayoffCell } from '../PoolsTable'
 import { config } from '../../constants'
 import { getDateTime } from '../../Util/Dates'
@@ -704,9 +704,9 @@ export default function Markets() {
                   onInputChange={handleCreatorInput}
                   MenuItemLabel="Diva Governance"
                   onMenuItemClick={() => {
-                    setCreatedBy(DIVA_GOVERNANCE_ADDRESS)
+                    setCreatedBy(DEFAULT_MARKETS_CREATED_BY)
                     setCreatorButtonLabel(
-                      getShortenedAddress(DIVA_GOVERNANCE_ADDRESS)
+                      getShortenedAddress(DEFAULT_MARKETS_CREATED_BY)
                     )
                   }}
                 />
@@ -831,7 +831,7 @@ export default function Markets() {
               }}
               onClearFilter={() => {
                 setSearch('')
-                setCreatedBy(DIVA_GOVERNANCE_ADDRESS)
+                setCreatedBy(DEFAULT_MARKETS_CREATED_BY)
                 setExpiredPoolClicked(false)
                 setSearchInput('')
                 setCheckedState(new Array(4).fill(false))

--- a/packages/diva-app/src/component/Markets/MobileFilterOptions.tsx
+++ b/packages/diva-app/src/component/Markets/MobileFilterOptions.tsx
@@ -17,7 +17,7 @@ import { useMemo } from 'react'
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp'
 
 import { getTopNObjectByProperty } from '../../Util/dashboard'
-import { DIVA_GOVERNANCE_ADDRESS } from '../../constants'
+import { DEFAULT_MARKETS_CREATED_BY } from '../../constants'
 
 const FilterAccordion = ({ title, children }) => {
   const theme = useTheme()
@@ -185,13 +185,13 @@ export const MobileFilterOptions = ({
           >
             <Box>Diva Governance</Box>
             <Checkbox
-              checked={createdBy === DIVA_GOVERNANCE_ADDRESS}
+              checked={createdBy === DEFAULT_MARKETS_CREATED_BY}
               id={`checkbox-diva-governance`}
               onChange={() => {
-                if (createdBy === DIVA_GOVERNANCE_ADDRESS) {
+                if (createdBy === DEFAULT_MARKETS_CREATED_BY) {
                   setCreatedBy('')
                 } else {
-                  setCreatedBy(DIVA_GOVERNANCE_ADDRESS)
+                  setCreatedBy(DEFAULT_MARKETS_CREATED_BY)
                 }
               }}
             />

--- a/packages/diva-app/src/constants.ts
+++ b/packages/diva-app/src/constants.ts
@@ -347,9 +347,13 @@ export const CURRENT_SUPPORTED_CHAIN_ID = [
   SupportedChainId.POLYGON_MUMBAI,
 ]
 
-// DIVA Governance address which is the default creator of pools on Markets page and trading fee recipient
-export const DIVA_GOVERNANCE_ADDRESS =
+// Pools created by this address to be displayed as default on the Markets page
+export const DEFAULT_MARKETS_CREATED_BY =
   '0x3E50a9F4DC9CCF7aFaBb7337cf57D63dFa12acc0'
+
+// Trading fee recipient
+export const TRADING_FEE_RECIPIENT =
+  '0x1062CCC9F9a4bBcf565799683b6c00eA525ECb9F'
 
 // Trading fee; 0.01 corresponds to 1%
 export const TRADING_FEE = 0.01


### PR DESCRIPTION
Split constant `DIVA_GOVERNANCE_ADDRESS` into `TRADING_FEE_RECIPIENT` and `DEFAULT_MARKETS_CREATED_BY` constants.

Observation: The filter by fee recipient doesn't seem to work as orders created with the previous recipient are still visible. Needs fixing in a separate PR