### PR TITLE
Fix token decimals issue in Create Pool

### DIFF
--- a/packages/diva-app/src/component/CreatePool/CreatePool.tsx
+++ b/packages/diva-app/src/component/CreatePool/CreatePool.tsx
@@ -85,7 +85,7 @@ export function CreatePool() {
         setDecimal(decimals)
       })
     }
-  }, [formik.values.collateralToken])
+  }, [formik.values.collateralToken, provider]) // provider trigger used to have the decimals updated on Create page open
   const handleConfigPick = (event: SelectChangeEvent) => {
     setConfigPicked(event.target.value)
   }

--- a/packages/diva-app/src/component/CreatePool/SelectDataFeedProvider.tsx
+++ b/packages/diva-app/src/component/CreatePool/SelectDataFeedProvider.tsx
@@ -108,8 +108,6 @@ export function SelectDataFeedProvider({
     [chainId, userAddress]
   )
 
-  console.log(config[chainId].adminAddress)
-
   return (
     <Stack direction={mobile ? 'column' : 'row'} spacing={theme.spacing(2)}>
       <Container>


### PR DESCRIPTION
## Technical Description

This PR addresses issue #801. The issue was caused because collateral token decimals were not updated if the collateral token was not changed from default (which is USDT). Adding `provider` as an additional trigger condition seems to fix this issue.