### PR TITLE
Fixed CoinIcon handling for urls with multiple '/'

### DIFF
--- a/packages/diva-app/src/component/CoinIcon.tsx
+++ b/packages/diva-app/src/component/CoinIcon.tsx
@@ -14,7 +14,6 @@ type CoinProps = {
 }
 
 const Placeholder = ({ asset }: CoinProps) => {
-  console.log('asset', asset)
   return (
     <svg height="100%" overflow="visible" viewBox="4 0 30 30">
       <circle

--- a/packages/diva-app/src/component/CoinIcon.tsx
+++ b/packages/diva-app/src/component/CoinIcon.tsx
@@ -14,6 +14,7 @@ type CoinProps = {
 }
 
 const Placeholder = ({ asset }: CoinProps) => {
+  console.log('asset', asset)
   return (
     <svg height="100%" overflow="visible" viewBox="4 0 30 30">
       <circle
@@ -78,15 +79,9 @@ const IconBox = ({ assetName, isLargeIcon }: CoinProps) => (
 
 export const CoinIconPair = ({ assetName, isLargeIcon }: CoinProps) => {
   const assets = assetName.split('/')
-  const isJson = assetName.endsWith('.json')
 
-  // Single asset or .json file
-  if (assets.length === 1 || isJson) {
-    return <IconBox assetName={assets[0]} isLargeIcon={isLargeIcon} />
-  }
-
-  // Two assets
   if (assets.length === 2) {
+    // Two assets
     return (
       <Stack direction="row">
         <IconBox assetName={assets[0]} isLargeIcon={isLargeIcon} />
@@ -95,9 +90,8 @@ export const CoinIconPair = ({ assetName, isLargeIcon }: CoinProps) => {
         </Box>
       </Stack>
     )
+  } else {
+    // Single asset, asset name with multiple '/' or .json file
+    return <IconBox assetName={assets[0]} isLargeIcon={isLargeIcon} />
   }
-
-  // Fallback
-  console.warn('Invalid assetName passed to CoinIconPair:', assetName)
-  return <Placeholder assetName={'?'} />
 }


### PR DESCRIPTION
Reference asset with multiple `/` such as `https://nftstorage.link/ipfs/bafkreicxs3vdqpqn4m26trh6p2gxi7i66zu6t4iael5hscpayc3hnlbtoq` caused the CoinIcon fetching logic to fail which resulted in an error on the Markets and Dashboard pages. This PR fixes this.