### PR TITLE
fix markets preview mode

### DIFF
--- a/packages/diva-app/src/component/ConnectionProvider.tsx
+++ b/packages/diva-app/src/component/ConnectionProvider.tsx
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux'
 import { setChainId, setUserAddress } from '../Redux/appSlice'
 import WalletConnectProvider from '@walletconnect/web3-provider'
 import Web3 from 'web3'
+import { MARKETS_PREVIEW_CHAIN_ID } from '../constants'
 
 type MetamaskProvider = ExternalProvider &
   BaseProvider & {
@@ -209,7 +210,7 @@ export const ConnectionProvider = ({ children }) => {
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (state.chainId == null) {
-        setState((_state) => ({ ..._state, chainId: 5 }))
+        setState((_state) => ({ ..._state, chainId: MARKETS_PREVIEW_CHAIN_ID }))
       }
     }, 3000)
     return () => clearTimeout(timeout)

--- a/packages/diva-app/src/component/CreatePool/ReviewAndSubmit.tsx
+++ b/packages/diva-app/src/component/CreatePool/ReviewAndSubmit.tsx
@@ -82,7 +82,7 @@ export function ReviewAndSubmit({
   )
   // QUESTION Why not use hook that will also handle null values?
   const diva = new ethers.Contract(
-    config[chainId!].divaAddress, //Goerli
+    config[chainId!].divaAddress,
     DIVA_ABI,
     provider.getSigner()
   )

--- a/packages/diva-app/src/component/Markets/Markets.tsx
+++ b/packages/diva-app/src/component/Markets/Markets.tsx
@@ -414,7 +414,7 @@ export default function Markets() {
     }, 300)
 
     return () => clearTimeout(timeout)
-  }, [createdBy, dispatch, history, page])
+  }, [createdBy, dispatch, history, page, chainId])
 
   useEffect(() => {
     const timeout = setTimeout(() => {

--- a/packages/diva-app/src/constants.ts
+++ b/packages/diva-app/src/constants.ts
@@ -365,6 +365,8 @@ export const DEFAULT_THRESHOLD = 100
 
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+export const MARKETS_PREVIEW_CHAIN_ID = 137
+
 export const ICONS_URL = {
   diva: divaLogo,
   divaSidebarLogo: divaSidebarLogo,


### PR DESCRIPTION
This PR fixes issue #807. Now by default, the Polygon markets are displayed if the user wallet is not connected.